### PR TITLE
Memory Pooling Refactor (LARGE)

### DIFF
--- a/CodingCPPAssignment3.vcxproj
+++ b/CodingCPPAssignment3.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="CodingCPPAssignment3.cpp" />
     <ClCompile Include="Entity.cpp" />
     <ClCompile Include="EntityManager.cpp" />
+    <ClCompile Include="EntityMemoryPool.cpp" />
     <ClCompile Include="GameEngine.cpp" />
     <ClCompile Include="MemoryMapping.cpp" />
     <ClCompile Include="Physics.cpp" />
@@ -152,6 +153,7 @@
     <ClInclude Include="Components.h" />
     <ClInclude Include="Entity.h" />
     <ClInclude Include="EntityManager.h" />
+    <ClInclude Include="EntityMemoryPool.h" />
     <ClInclude Include="GameEngine.h" />
     <ClInclude Include="MemoryMapping.h" />
     <ClInclude Include="Physics.h" />

--- a/Entity.cpp
+++ b/Entity.cpp
@@ -1,14 +1,12 @@
 #include "Entity.h"
 
-Entity::Entity(const size_t& id) :
+Entity::Entity(const size_t id) :
 	m_id(id)
-{
-
-}
+{ }
 
 void Entity::destroy()
 {
-	m_active = false;
+	EntityMemoryPool::Instance().destroy(m_id);
 }
 
 const size_t Entity::id() const
@@ -18,10 +16,10 @@ const size_t Entity::id() const
 
 bool Entity::isActive() const
 {
-	return m_active;
+	return EntityMemoryPool::Instance().isActive(m_id);
 }
 
 const std::string& Entity::tag() const
 {
-	return m_tag;
+	return EntityMemoryPool::Instance().getTag(m_id);
 }

--- a/Entity.cpp
+++ b/Entity.cpp
@@ -1,8 +1,7 @@
 #include "Entity.h"
 
-Entity::Entity(const size_t& id, const std::string& tag) :
-	m_id(id),
-	m_tag(tag)
+Entity::Entity(const size_t& id) :
+	m_id(id)
 {
 
 }

--- a/Entity.h
+++ b/Entity.h
@@ -1,69 +1,40 @@
 #pragma once
 
-#include "Components.h"
+#include "EntityMemoryPool.h"
 
 #include <tuple>
 #include <string>
 
-class EntityManager;
-
-typedef std::tuple<CTransform, CLifespan, CInput, CBoundingBox, CAnimation, CGravity, CState, CDraggable> ComponentTuple;
+class EntityMemoryPool;
 
 class Entity
 {
-	friend class EntityManager;
+	friend EntityMemoryPool;
+	size_t		m_id;
 
-	bool						m_active = true;
-	std::string					m_tag = "default";
-	size_t						m_id = 0;
-	ComponentTuple				m_components;
-
-	// How to access items in a tuple
-	//std::tuple<int, double, char> m_myTuple;
-	//std::get<int>(m_myTuple);
-	// so you can do:
-	//std::get<CTransform>(m_components); - gets transform component from that container m_components
-
-	// Constructor is private so we can never create entities outside
-	// the EntityManager which has friend access
-	Entity(const size_t& id, const std::string& tag);
-
+	Entity(const size_t& id);
 public:
-	void						destroy();
-	const size_t				id()			const;
-	bool						isActive()		const;
-	const std::string&			tag()			const;
+	template<typename T>
+	T& getComponent()
+	{
+		return EntityMemoryPool::Instance().getComponent<T>(m_id);
+	}
 
 	template <typename T>
 	bool hasComponent() const
 	{
-		return getComponent<T>().has;
+		return EntityMemoryPool::Instance().hasComponent<T>(m_id);
 	}
 
-	template <typename T, typename... TArgs>
-	T& addComponent(TArgs&&... mArgs)
+	template <typename T>
+	T& addComponent()
 	{
-		auto& component = getComponent<T>();
-		component = T(std::forward<TArgs>(mArgs)...);
-		component.has = true;
-		return component;
+		return EntityMemoryPool::Instance.addComponent<T>(m_id);
 	}
 
-	template<typename T>
-	T& getComponent()
+	template <typename T>
+	T& removeComponent()
 	{
-		return std::get<T>(m_components);
-	}
-
-	template<typename T>
-	const T& getComponent() const
-	{
-		return std::get<T>(m_components);
-	}
-
-	template<typename T>
-	void removeComponent()
-	{
-		getComponent<T>() = T();
+		return EntityMemoryPool::Instance().removeComponent<T>(m_id);
 	}
 };

--- a/Entity.h
+++ b/Entity.h
@@ -12,9 +12,21 @@ class Entity
 	friend EntityMemoryPool;
 	size_t		m_id;
 
-	Entity(const size_t& id);
+	Entity(const size_t id);
 public:
-	template<typename T>
+
+	void destroy();
+	const size_t id() const;
+	bool isActive() const;
+	const std::string& tag() const;
+
+	template <typename T, typename... TArgs>
+	T& addComponent(TArgs&&... mArgs)
+	{
+		return EntityMemoryPool::Instance().addComponent<T>(m_id, mArgs);
+	}
+
+	template <typename T>
 	T& getComponent()
 	{
 		return EntityMemoryPool::Instance().getComponent<T>(m_id);
@@ -24,12 +36,6 @@ public:
 	bool hasComponent() const
 	{
 		return EntityMemoryPool::Instance().hasComponent<T>(m_id);
-	}
-
-	template <typename T>
-	T& addComponent()
-	{
-		return EntityMemoryPool::Instance.addComponent<T>(m_id);
 	}
 
 	template <typename T>

--- a/Entity.h
+++ b/Entity.h
@@ -23,7 +23,7 @@ public:
 	template <typename T, typename... TArgs>
 	T& addComponent(TArgs&&... mArgs)
 	{
-		return EntityMemoryPool::Instance().addComponent<T>(m_id, mArgs);
+		return EntityMemoryPool::Instance().addComponent<T>(m_id, std::forward<TArgs>(mArgs)...);
 	}
 
 	template <typename T>

--- a/EntityManager.cpp
+++ b/EntityManager.cpp
@@ -34,7 +34,7 @@ void EntityManager::removeDeadEntities(EntityVec& vec)
 		[](auto e)
 		{
 			//std::cout << "Removing dead entity: " << e->id() << "\n";
-			return !e->isActive();
+			return !e.isActive();
 		});
 
 	vec.erase(ne, vec.end());
@@ -42,7 +42,7 @@ void EntityManager::removeDeadEntities(EntityVec& vec)
 
 Entity EntityManager::addEntity(const std::string& tag)
 {
-	Entity e = EntityMemoryPool::Instance().addEntity(tag);
+	auto e = EntityMemoryPool::Instance().addEntity(tag);
 	m_entitiesToAdd.push_back(e);
 	return e;
 }

--- a/EntityManager.cpp
+++ b/EntityManager.cpp
@@ -12,7 +12,7 @@ void EntityManager::update()
 	for (auto& e : m_entitiesToAdd)
 	{
 		m_entities.push_back(e);
-		m_entityMap[e->tag()].push_back(e);
+		m_entityMap[e.tag()].push_back(e);
 	}
 
 	m_entitiesToAdd.clear();
@@ -40,12 +40,11 @@ void EntityManager::removeDeadEntities(EntityVec& vec)
 	vec.erase(ne, vec.end());
 }
 
-std::shared_ptr<Entity> EntityManager::addEntity(const std::string& tag)
+Entity EntityManager::addEntity(const std::string& tag)
 {
-	auto entity = std::shared_ptr<Entity>(new Entity(m_totalEntities++, tag));
-	m_entitiesToAdd.push_back(entity);
-
-	return entity;
+	Entity e = EntityMemoryPool::Instance().addEntity(tag);
+	m_entitiesToAdd.push_back(e);
+	return e;
 }
 
 const EntityVec& EntityManager::getEntities()

--- a/EntityManager.cpp
+++ b/EntityManager.cpp
@@ -42,17 +42,20 @@ void EntityManager::removeDeadEntities(EntityVec& vec)
 
 Entity EntityManager::addEntity(const std::string& tag)
 {
-	auto e = EntityMemoryPool::Instance().addEntity(tag);
-	m_entitiesToAdd.push_back(e);
-	return e;
+	//auto e = EntityMemoryPool::Instance().addEntity(tag);
+	//m_entitiesToAdd.push_back(e);
+	//
+	// return e;
+
+	return EntityMemoryPool::Instance().addEntity(tag);
 }
 
 const EntityVec& EntityManager::getEntities()
 {
-	return m_entities;
+	return EntityMemoryPool::Instance().getEntities();
 }
 
 const EntityVec& EntityManager::getEntities(const std::string& tag)
 {
-	return m_entityMap[tag];
+	return EntityMemoryPool::Instance().getEntities(tag);
 }

--- a/EntityManager.cpp
+++ b/EntityManager.cpp
@@ -23,6 +23,7 @@ void EntityManager::update()
 	{
 		removeDeadEntities(entityVec);
 	}
+
 	removeDeadEntities(m_entities);
 }
 
@@ -42,20 +43,17 @@ void EntityManager::removeDeadEntities(EntityVec& vec)
 
 Entity EntityManager::addEntity(const std::string& tag)
 {
-	//auto e = EntityMemoryPool::Instance().addEntity(tag);
-	//m_entitiesToAdd.push_back(e);
-	//
-	// return e;
-
-	return EntityMemoryPool::Instance().addEntity(tag);
+	Entity e = EntityMemoryPool::Instance().addEntity(tag);
+	m_entitiesToAdd.push_back(e);
+	return e;
 }
 
 const EntityVec& EntityManager::getEntities()
 {
-	return EntityMemoryPool::Instance().getEntities();
+	return m_entities;
 }
 
 const EntityVec& EntityManager::getEntities(const std::string& tag)
 {
-	return EntityMemoryPool::Instance().getEntities(tag);
+	return m_entityMap[tag];
 }

--- a/EntityManager.h
+++ b/EntityManager.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "Entity.h"
+#include "Components.h"
+#include "EntityMemoryPool.h"
 
 #include <vector>
 #include <map>
 
-typedef std::vector<std::shared_ptr<Entity>> EntityVec;
+typedef std::vector<Entity> EntityVec;
 
 class EntityManager
 {
@@ -18,12 +20,11 @@ class EntityManager
 	void removeDeadEntities(EntityVec& vec);
 
 public:
-
 	EntityManager();
 
 	void update();
 
-	std::shared_ptr<Entity> addEntity(const std::string& tag);
+	Entity addEntity(const std::string& tag);
 
 	const EntityVec& getEntities();
 	const EntityVec& getEntities(const std::string& tag);

--- a/EntityMemoryPool.cpp
+++ b/EntityMemoryPool.cpp
@@ -1,4 +1,5 @@
 #include "EntityMemoryPool.h"
+#include "Entity.h"
 
 EntityMemoryPool::EntityMemoryPool(size_t maxEnts) :
 	m_maxEntities(maxEnts)
@@ -9,10 +10,10 @@ EntityMemoryPool::EntityMemoryPool(size_t maxEnts) :
 void EntityMemoryPool::reserveAll(size_t maxNum)
 {
 	// Allocated memory for every vector using MAX_ENTITIES
-	m_tags.reserve(maxNum);
-	m_active.reserve(maxNum);
+	m_tags.resize(maxNum);
+	m_active.resize(maxNum, false);
 	std::apply([maxNum](auto&... vectors) {
-		(..., vectors.reserve(maxNum));
+		(..., vectors.resize(maxNum));
 		}, m_pool);
 }
 
@@ -32,13 +33,13 @@ bool EntityMemoryPool::isActive(size_t id) const
 }
 
 Entity EntityMemoryPool::addEntity(const std::string& tag)
-	{
+{
 	size_t index = getNextEntityIndex();
 
 	m_tags[index] = tag;
 	m_active[index] = true;
 	return Entity(index);
-	}
+}
 
 size_t EntityMemoryPool::getNextEntityIndex()
 {

--- a/EntityMemoryPool.cpp
+++ b/EntityMemoryPool.cpp
@@ -1,5 +1,6 @@
 #include "EntityMemoryPool.h"
 #include "Entity.h"
+#include <iostream>
 
 EntityMemoryPool::EntityMemoryPool(size_t maxEnts) :
 	m_maxEntities(maxEnts)
@@ -41,6 +42,36 @@ Entity EntityMemoryPool::addEntity(const std::string& tag)
 	return Entity(index);
 }
 
+std::vector<Entity> EntityMemoryPool::getEntities()
+{
+	std::vector<Entity> taggedEntities;
+
+	for (int i = 0; i < MAX_ENTITIES; i++)
+	{
+		if (m_active[i])
+		{
+			taggedEntities.push_back(std::get<std::vector<Entity>>(m_pool)[i]);
+		}
+	}
+
+	return taggedEntities;
+}
+
+std::vector<Entity>& EntityMemoryPool::getEntities(const std::string& tag)
+{
+	std::vector<Entity> taggedEntities;
+
+	for (int i = 0; i < MAX_ENTITIES; i++)
+	{
+		if (m_tags[i] == tag && m_active[i])
+		{
+			taggedEntities.push_back(std::get<std::vector<Entity>>(m_pool)[i]);
+		}
+	}
+
+	return taggedEntities;
+}
+
 size_t EntityMemoryPool::getNextEntityIndex()
 {
 	if (m_numEntities < MAX_ENTITIES)
@@ -64,6 +95,7 @@ size_t EntityMemoryPool::getNextEntityIndex()
 		// TODO
 		// Handle error here for exceeding max num of entities allowed
 		// but for now do nothing (don't add entity)
+		std::cout << "Max entity count exceeded!!!" << std::endl;
 	}
 
 	return 0;

--- a/EntityMemoryPool.cpp
+++ b/EntityMemoryPool.cpp
@@ -1,0 +1,69 @@
+#include "EntityMemoryPool.h"
+
+EntityMemoryPool::EntityMemoryPool(size_t maxEnts) :
+	m_maxEntities(maxEnts)
+{
+	reserveAll(MAX_ENTITIES);
+}
+
+void EntityMemoryPool::reserveAll(size_t maxNum)
+{
+	// Allocated memory for every vector using MAX_ENTITIES
+	m_tags.reserve(maxNum);
+	m_active.reserve(maxNum);
+	std::apply([maxNum](auto&... vectors) {
+		(..., vectors.reserve(maxNum));
+		}, m_pool);
+}
+
+void EntityMemoryPool::destroy(size_t id)
+{
+	m_active[id] = false;
+}
+
+const std::string& EntityMemoryPool::getTag(size_t id) const
+{
+	return m_tags[id];
+}
+
+bool EntityMemoryPool::isActive(size_t id) const
+{
+	return m_active[id];
+}
+
+Entity EntityMemoryPool::addEntity(const std::string& tag)
+{
+	size_t index = getNextEntityIndex();
+
+	m_tags[index] = tag;
+	m_active[index] = true;
+	return Entity(index);
+}
+
+size_t EntityMemoryPool::getNextEntityIndex()
+{
+	if (m_numEntities < MAX_ENTITIES)
+	{
+		// We have room to add an entity
+		for (int i = 0; i < MAX_ENTITIES; i++)
+		{
+			// Found an index marked as inactive (we can use this slot)
+			if (!m_active[i])
+			{
+				// We will need to decrement when we call destroy() on an entity
+				m_numEntities++;
+
+				// return inactive index to be used
+				return i;
+			}
+		}
+	}
+	else
+	{
+		// TODO
+		// Handle error here for exceeding max num of entities allowed
+		// but for now do nothing (don't add entity)
+	}
+
+	return 0;
+}

--- a/EntityMemoryPool.h
+++ b/EntityMemoryPool.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <string>
 
-static const size_t MAX_ENTITIES = 10000;
+static const size_t MAX_ENTITIES = 100000;
 
 typedef std::tuple<
 	std::vector<CTransform>,
@@ -38,6 +38,8 @@ public:
 	void destroy(size_t entityId);
 	size_t getNextEntityIndex();
 	Entity addEntity(const std::string& tag);
+	std::vector<Entity> getEntities();
+	std::vector<Entity>& getEntities(const std::string& tag);
 
 	static EntityMemoryPool& Instance()
 	{

--- a/EntityMemoryPool.h
+++ b/EntityMemoryPool.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "Components.h"
+#include "Entity.h"
+
+#include <vector>
+#include <string>
+
+static const size_t MAX_ENTITIES = 10000;
+
+typedef std::tuple<
+	std::vector<CTransform>,
+	std::vector<CLifespan>,
+	std::vector<CInput>,
+	std::vector<CBoundingBox>,
+	std::vector<CAnimation>,
+	std::vector<CGravity>,
+	std::vector<CState>,
+	std::vector<CDraggable>> EntityComponentVectorTuple;
+
+class EntityMemoryPool
+{
+	size_t							m_numEntities;
+	EntityComponentVectorTuple		m_pool;
+	std::vector<std::string>		m_tags;
+	std::vector<bool>				m_active;
+
+	EntityMemoryPool(size_t maxEntities);
+
+public:
+	static EntityMemoryPool& Instance()
+	{
+		static EntityMemoryPool pool(MAX_ENTITIES);
+		return pool;
+	}
+
+	template <typename T>
+	T& getComponent(size_t entityId)
+	{
+		return std::get<std::vector<T>>(m_pool)[entityId];
+	}
+
+	template <typename T>
+	const T& getComponent(size_t entityId) const
+	{
+		return std::get<std::vector<T>>(m_pool)[entityId];
+	}
+
+	template <typename T>
+	T& hasComponent(size_t entityId)
+	{
+		return std::get<std::vector<T>>(m_data)[entityId].has;
+	}
+
+	template <typename T, typename... TArgs>
+	T& addComponent(TArgs&&... mArgs)
+	{
+		auto& component = getComponent<T>();
+		component = T(std::forward<TArgs>(mArgs)...);
+		component.has = true;
+		return component;
+	}
+
+	template <typename T>
+	size_t getNextEntityIndex()
+	{
+		auto pp = std::get<std::vector<T>>(m_pool);
+
+		return 0;
+	}
+
+	template <typename T>
+	void removeComponent(size_t entityId)
+	{
+		getComponent<T>(entityId) = T(entityId);
+	}
+
+	Entity addEntity(const std::string& tag)
+	{
+		size_t index = getNextEntityIndex();
+
+		m_tags[index] = tag;
+		m_active[index] = true;
+		return Entity(index);
+	}
+
+	const std::string& getTag(size_t entityId) const
+	{
+		return m_tags[entityId];
+	}
+};

--- a/EntityMemoryPool.h
+++ b/EntityMemoryPool.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "Components.h"
-#include "Entity.h"
+//#include "Entity.h"
 
 #include <vector>
 #include <string>
@@ -17,6 +17,8 @@ typedef std::tuple<
 	std::vector<CGravity>,
 	std::vector<CState>,
 	std::vector<CDraggable>> EntityComponentVectorTuple;
+
+class Entity;
 
 class EntityMemoryPool
 {

--- a/EntityMemoryPool.h
+++ b/EntityMemoryPool.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <string>
 
-static const size_t MAX_ENTITIES = 100000;
+static const size_t MAX_ENTITIES = 1000000;
 
 typedef std::tuple<
 	std::vector<CTransform>,
@@ -30,6 +30,7 @@ class EntityMemoryPool
 
 	EntityMemoryPool(size_t maxEntities);
 	void reserveAll(size_t maxEntities);
+	void removeAllComponents(size_t entityId);
 
 public:
 
@@ -38,8 +39,6 @@ public:
 	void destroy(size_t entityId);
 	size_t getNextEntityIndex();
 	Entity addEntity(const std::string& tag);
-	std::vector<Entity> getEntities();
-	std::vector<Entity>& getEntities(const std::string& tag);
 
 	static EntityMemoryPool& Instance()
 	{

--- a/Physics.cpp
+++ b/Physics.cpp
@@ -1,34 +1,34 @@
 #include "Physics.h"
 
-Vec2 Physics::GetOverlap(std::shared_ptr<Entity> a, std::shared_ptr<Entity> b)
+Vec2 Physics::GetOverlap(Entity a, Entity b)
 {
-	if (a->hasComponent<CBoundingBox>() && b->hasComponent<CBoundingBox>())
+	if (a.hasComponent<CBoundingBox>() && b.hasComponent<CBoundingBox>())
 	{
-		Vec2 delta(abs(b->getComponent<CTransform>().pos.x - a->getComponent<CTransform>().pos.x),
-			abs(b->getComponent<CTransform>().pos.y - a->getComponent<CTransform>().pos.y));
-		float XOverlap = a->getComponent<CBoundingBox>().halfSize.x + b->getComponent<CBoundingBox>().halfSize.x - delta.x;
-		float YOverlap = a->getComponent<CBoundingBox>().halfSize.y + b->getComponent<CBoundingBox>().halfSize.y - delta.y;
+		Vec2 delta(abs(b.getComponent<CTransform>().pos.x - a.getComponent<CTransform>().pos.x),
+			abs(b.getComponent<CTransform>().pos.y - a.getComponent<CTransform>().pos.y));
+		float XOverlap = a.getComponent<CBoundingBox>().halfSize.x + b.getComponent<CBoundingBox>().halfSize.x - delta.x;
+		float YOverlap = a.getComponent<CBoundingBox>().halfSize.y + b.getComponent<CBoundingBox>().halfSize.y - delta.y;
 		return Vec2(XOverlap, YOverlap);
 	}
 	else { return Vec2(0, 0); }
 }
 
-Vec2 Physics::GetPreviousOverlap(std::shared_ptr<Entity> a, std::shared_ptr<Entity> b)
+Vec2 Physics::GetPreviousOverlap(Entity a, Entity b)
 {
-	if (a->hasComponent<CBoundingBox>() && b->hasComponent<CBoundingBox>())
+	if (a.hasComponent<CBoundingBox>() && b.hasComponent<CBoundingBox>())
 	{
-		Vec2 delta(abs(b->getComponent<CTransform>().pos.x - a->getComponent<CTransform>().prevPos.x),
-			abs(b->getComponent<CTransform>().pos.y - a->getComponent<CTransform>().prevPos.y));
-		float XOverlap = a->getComponent<CBoundingBox>().halfSize.x + b->getComponent<CBoundingBox>().halfSize.x - delta.x;
-		float YOverlap = a->getComponent<CBoundingBox>().halfSize.y + b->getComponent<CBoundingBox>().halfSize.y - delta.y;
+		Vec2 delta(abs(b.getComponent<CTransform>().pos.x - a.getComponent<CTransform>().prevPos.x),
+			abs(b.getComponent<CTransform>().pos.y - a.getComponent<CTransform>().prevPos.y));
+		float XOverlap = a.getComponent<CBoundingBox>().halfSize.x + b.getComponent<CBoundingBox>().halfSize.x - delta.x;
+		float YOverlap = a.getComponent<CBoundingBox>().halfSize.y + b.getComponent<CBoundingBox>().halfSize.y - delta.y;
 		return Vec2(XOverlap, YOverlap);
 	}
 	else { return Vec2(0, 0); }
 }
 
-bool Physics::IsInside(const Vec2& pos, std::shared_ptr<Entity> e)
+bool Physics::IsInside(const Vec2& pos, Entity e)
 {
-	sf::FloatRect globalBounds = e->getComponent<CAnimation>().animation.getSprite().getGlobalBounds();
+	sf::FloatRect globalBounds = e.getComponent<CAnimation>().animation.getSprite().getGlobalBounds();
 	if (pos.x > globalBounds.position.x && pos.x < globalBounds.position.x + globalBounds.size.x &&
 		pos.y > globalBounds.position.y && pos.y < globalBounds.position.y + globalBounds.size.y)
 	{
@@ -57,9 +57,9 @@ Intersect Physics::LineIntersect(const Vec2& a, const Vec2& b, const Vec2& c, co
 	}
 }
 
-bool Physics::EntityIntersect(const Vec2& a, const Vec2& b, std::shared_ptr<Entity> e)
+bool Physics::EntityIntersect(const Vec2& a, const Vec2& b, Entity e)
 {
-	sf::FloatRect globalBounds = e->getComponent<CAnimation>().animation.getSprite().getGlobalBounds();
+	sf::FloatRect globalBounds = e.getComponent<CAnimation>().animation.getSprite().getGlobalBounds();
 	Vec2 topLeft = Vec2(globalBounds.position.x, globalBounds.position.y);
 	Vec2 topRight = Vec2(globalBounds.position.x + globalBounds.size.x, globalBounds.position.y);
 	Vec2 bottomLeft = Vec2(globalBounds.position.x, globalBounds.position.y + globalBounds.size.y);

--- a/Physics.h
+++ b/Physics.h
@@ -14,9 +14,9 @@ public:
 
 	Physics() {}
 
-	Vec2 static GetOverlap(std::shared_ptr<Entity> a, std::shared_ptr<Entity> b);
-	Vec2 static GetPreviousOverlap(std::shared_ptr<Entity> a, std::shared_ptr<Entity> b);
-	bool static IsInside(const Vec2& pos, std::shared_ptr<Entity> e);
+	Vec2 static GetOverlap(Entity a, Entity b);
+	Vec2 static GetPreviousOverlap(Entity a, Entity b);
+	bool static IsInside(const Vec2& pos, Entity e);
 	Intersect LineIntersect(const Vec2& a, const Vec2& b, const Vec2& c, const Vec2& d);
-	bool EntityIntersect(const Vec2& a, const Vec2& b, std::shared_ptr<Entity> e);
+	bool EntityIntersect(const Vec2& a, const Vec2& b, Entity e);
 };

--- a/Scene_Menu.cpp
+++ b/Scene_Menu.cpp
@@ -34,10 +34,10 @@ void Scene_Menu::init()
 	m_levelPaths.push_back("levels/level1.txt");
 
 	auto menuCharacter = m_entityManager.addEntity("Tile");
-	menuCharacter->addComponent<CAnimation>(m_game->assets().getAnimation("PlayerRun"), true);
-	menuCharacter->addComponent<CTransform>();
-	menuCharacter->getComponent<CTransform>().scale = { 7, 7 };
-	menuCharacter->getComponent<CTransform>().pos = { (float)m_game->window().getSize().x / 2.0f, (float)m_game->window().getSize().y / 2.0f };
+	menuCharacter.addComponent<CAnimation>(m_game->assets().getAnimation("PlayerRun"), true);
+	menuCharacter.addComponent<CTransform>();
+	menuCharacter.getComponent<CTransform>().scale = { 7, 7 };
+	menuCharacter.getComponent<CTransform>().pos = { (float)m_game->window().getSize().x / 2.0f, (float)m_game->window().getSize().y / 2.0f };
 
 	registerAction(sf::Keyboard::Key::W,		"UP");
 	registerAction(sf::Keyboard::Key::S,		"DOWN");
@@ -88,11 +88,11 @@ void Scene_Menu::sDoAction(const Action& action)
 
 void Scene_Menu::sAnimation()
 {
-	for (auto& e : m_entityManager.getEntities())
+	for (auto e : m_entityManager.getEntities())
 	{
-		if (e->hasComponent<CAnimation>())
+		if (e.hasComponent<CAnimation>())
 		{
-			e->getComponent<CAnimation>().animation.update();
+			e.getComponent<CAnimation>().animation.update();
 		}
 	}
 }
@@ -165,13 +165,13 @@ void Scene_Menu::sRender()
 			m_menuTextBackground.setOutlineThickness(2);
 		}
 
-		for (auto& e : m_entityManager.getEntities())
+		for (auto e : m_entityManager.getEntities())
 		{
-			auto& transform = e->getComponent<CTransform>();
+			auto& transform = e.getComponent<CTransform>();
 
-			if (e->hasComponent<CAnimation>())
+			if (e.hasComponent<CAnimation>())
 			{
-				auto& animation = e->getComponent<CAnimation>().animation;
+				auto& animation = e.getComponent<CAnimation>().animation;
 				animation.getSprite().setPosition({ transform.pos.x, transform.pos.y });
 				animation.getSprite().setScale({ transform.scale.x, transform.scale.y });
 				m_game->window().draw(animation.getSprite());

--- a/Scene_Play.cpp
+++ b/Scene_Play.cpp
@@ -8,10 +8,10 @@
 #include <iostream>
 #include <fstream>
 
-bool isInside(Vec2 pos, std::shared_ptr<Entity> e)
+bool isInside(Vec2 pos, Entity e)
 {
-	auto ePos = e->getComponent<CTransform>().pos;
-	auto size = e->getComponent<CAnimation>().animation.getSize();
+	auto ePos = e.getComponent<CTransform>().pos;
+	auto size = e.getComponent<CAnimation>().animation.getSize();
 	float dx = fabs(pos.x - ePos.x);
 	float dy = fabs(pos.y - ePos.y);
 
@@ -47,7 +47,7 @@ void Scene_Play::init(const std::string& levelPath)
 }
 
 // IMPORTANT: Always add the CAnimation component first so that gridToMidPixel can compute correctly
-Vec2 Scene_Play::gridToMidPixel(float gridX, float gridY, std::shared_ptr<Entity> entity)
+Vec2 Scene_Play::gridToMidPixel(float gridX, float gridY, Entity entity)
 {
 	//			This function takes in a grid (x, y) position and an Entity
 	//			Return a Vec2 indicating where the CENTER position of the Entity should be
@@ -56,8 +56,8 @@ Vec2 Scene_Play::gridToMidPixel(float gridX, float gridY, std::shared_ptr<Entity
 	//			The bottom-left corner of the Animation should align with the bottom left of the grid cell
 
 	float x = 0.0f, y = 0.0f;
-	x = (gridX * m_gridSize.x) + (entity->getComponent<CAnimation>().animation.getSize().x / 2);
-	y = m_game->window().getSize().y - (gridY * m_gridSize.y) - (entity->getComponent<CAnimation>().animation.getSize().y / 2 * entity->getComponent<CTransform>().scale.y);
+	x = (gridX * m_gridSize.x) + (entity.getComponent<CAnimation>().animation.getSize().x / 2);
+	y = m_game->window().getSize().y - (gridY * m_gridSize.y) - (entity.getComponent<CAnimation>().animation.getSize().y / 2 * entity.getComponent<CTransform>().scale.y);
 
 	return Vec2(x, y);
 }
@@ -136,6 +136,8 @@ void Scene_Play::loadLevel(const std::string& filename)
 	}
 
 	spawnPlayer();
+
+
 	//      NOTE:
 	//------  THIS IS INCREDIBLY IMPORTANT PLEASE READ THIS EXAMPLE  ----------
 	//		Components are now returned as references rather than pointers. If you
@@ -153,8 +155,7 @@ void Scene_Play::loadLevel(const std::string& filename)
 
 void Scene_Play::spawnPlayer()
 {
-	// Here is a sample player entity which you can use to construct other entities
-	m_player = m_entityManager.addEntity("Player");
+	//m_player = m_entityManager.addEntity("Player");
 	m_player.addComponent<CAnimation>(m_game->assets().getAnimation("PlayerJump"), true);
 	m_player.addComponent<CTransform>(Vec2(gridToMidPixel(m_playerConfig.gridX, m_playerConfig.gridY, m_player)));
 	m_player.addComponent<CState>().state = "JUMPING";
@@ -162,7 +163,7 @@ void Scene_Play::spawnPlayer()
 	m_player.addComponent<CGravity>(m_playerConfig.gravity);
 }
 
-void Scene_Play::spawnBullet(std::shared_ptr<Entity> entity)
+void Scene_Play::spawnBullet(Entity entity)
 {
 	// TODO: This should spawn a bullet at the given entity, going in the direction the entity is facing
 	auto bullet = m_entityManager.addEntity("Bullet");
@@ -204,7 +205,7 @@ void Scene_Play::sDragAndDrop()
 
 void Scene_Play::sLifespan()
 {
-	for (auto& e : m_entityManager.getEntities())
+	for (auto e : m_entityManager.getEntities())
 	{
 		if (e.hasComponent<CLifespan>())
 		{
@@ -238,7 +239,7 @@ void Scene_Play::sStatus()
 	// - LIVING
 	// - DYING // Dying takes time, set animation depending on frames for the animation, once the animation ends, sAnimation() calls destroy() on the entity
 
-	for (auto& e : m_entityManager.getEntities())
+	for (auto e : m_entityManager.getEntities())
 	{
 		if (e.hasComponent<CState>())
 		{
@@ -386,7 +387,7 @@ void Scene_Play::sCollision()
 	Vec2 overlap(0, 0);
 	auto& pPos = m_player.getComponent<CTransform>();
 
-	for (auto& e : m_entityManager.getEntities("Tile"))
+	for (auto e : m_entityManager.getEntities("Tile"))
 	{
 		overlap = Physics::GetOverlap(e, m_player);
 		// Collision detected
@@ -430,7 +431,7 @@ void Scene_Play::sCollision()
 			}
 		}
 
-		for (auto& b : m_entityManager.getEntities("Bullet"))
+		for (auto b : m_entityManager.getEntities("Bullet"))
 		{
 			overlap = Physics::GetOverlap(e, b);
 			if (overlap.x > 0 && overlap.y > 0)
@@ -463,17 +464,17 @@ void Scene_Play::sDoAction(const Action& action)
 		if (action.name() == "TOGGLE_GRID")			{ m_drawGrid = !m_drawGrid; }
 		if (action.name() == "PAUSE")				{ setPaused(!m_paused); }
 		if (action.name() == "QUIT")				{ onEnd(); }
-		if (action.name() == "JUMP")				{m_player->getComponent<CInput>().up = true; }
-		if (action.name() == "CROUCH")				{ m_player->getComponent<CInput>().down = true; }
-		if (action.name() == "LEFT")				{ m_player->getComponent<CInput>().left = true; }
-		if (action.name() == "RIGHT")				{ m_player->getComponent<CInput>().right = true; }
-		if (action.name() == "SHOOT")				{ m_player->getComponent<CInput>().shoot = true; }
-		if (action.name() == "SPECIAL")				{ m_player->getComponent<CInput>().special = true; }
+		if (action.name() == "JUMP")				{ m_player.getComponent<CInput>().up = true; }
+		if (action.name() == "CROUCH")				{ m_player.getComponent<CInput>().down = true; }
+		if (action.name() == "LEFT")				{ m_player.getComponent<CInput>().left = true; }
+		if (action.name() == "RIGHT")				{ m_player.getComponent<CInput>().right = true; }
+		if (action.name() == "SHOOT")				{ m_player.getComponent<CInput>().shoot = true; }
+		if (action.name() == "SPECIAL")				{ m_player.getComponent<CInput>().special = true; }
 		if (action.name() == "LEFT_CLICK")			
 		{ 
 			Vec2 worldPos = windowToWorld(action.pos());
 			//std::cout << "Mouse clicked at: " << worldPos.x << ", " << worldPos.y << std::endl;
-			for (auto& e : m_entityManager.getEntities())
+			for (auto e : m_entityManager.getEntities())
 			{
 				if (e.hasComponent<CDraggable>() && isInside(worldPos, e))
 				{
@@ -490,10 +491,10 @@ void Scene_Play::sDoAction(const Action& action)
 	}
 	else if (action.type() == "END")
 	{
-		if (action.name() == "JUMP")				{ m_player->getComponent<CInput>().up = false; }
-		if (action.name() == "CROUCH")				{ m_player->getComponent<CInput>().down = false; }
-		if (action.name() == "LEFT")				{ m_player->getComponent<CInput>().left = false; }
-		if (action.name() == "RIGHT")				{ m_player->getComponent<CInput>().right = false; }
+		if (action.name() == "JUMP")				{ m_player.getComponent<CInput>().up = false; }
+		if (action.name() == "CROUCH")				{ m_player.getComponent<CInput>().down = false; }
+		if (action.name() == "LEFT")				{ m_player.getComponent<CInput>().left = false; }
+		if (action.name() == "RIGHT")				{ m_player.getComponent<CInput>().right = false; }
 		if (action.name() == "SHOOT") 
 		{
 			m_player.getComponent<CInput>().canShoot = true;
@@ -504,23 +505,23 @@ void Scene_Play::sDoAction(const Action& action)
 
 void Scene_Play::sAnimation()
 {
-	for (auto& e : m_entityManager.getEntities())
+	for (auto e : m_entityManager.getEntities())
 	{
-		if (e->hasComponent<CAnimation>())
+		if (e.hasComponent<CAnimation>())
 		{
-			if (e->getComponent<CAnimation>().repeat)
+			if (e.getComponent<CAnimation>().repeat)
 			{
-				e->getComponent<CAnimation>().animation.update();
+				e.getComponent<CAnimation>().animation.update();
 			}
 			else
 			{
-				if (e->getComponent<CAnimation>().animation.hasEnded())
+				if (e.getComponent<CAnimation>().animation.hasEnded())
 				{
-					e->destroy();
+					e.destroy();
 				}
 				else
 				{
-					e->getComponent<CAnimation>().animation.update();
+					e.getComponent<CAnimation>().animation.update();
 				}
 			}
 		}
@@ -534,7 +535,7 @@ void Scene_Play::sRender()
 	else { m_game->window().clear(sf::Color(0xa83ea8)); }
 
 	// Set the viewport of the window to be centered on the player if it's far enough right
-	auto& pPos = m_player->getComponent<CTransform>().pos;
+	auto& pPos = m_player.getComponent<CTransform>().pos;
 	float windowCenterX = std::max(m_game->window().getSize().x / 2.0f, pPos.x);
 	sf::View view = m_game->window().getView();
 	view.setCenter({ windowCenterX, m_game->window().getSize().y - view.getCenter().y });
@@ -545,11 +546,11 @@ void Scene_Play::sRender()
 	{
 		for (auto e : m_entityManager.getEntities())
 		{
-			auto& transform = e->getComponent<CTransform>();
+			auto& transform = e.getComponent<CTransform>();
 
-			if (e->hasComponent<CAnimation>())
+			if (e.hasComponent<CAnimation>())
 			{
-				auto& animation = e->getComponent<CAnimation>().animation;
+				auto& animation = e.getComponent<CAnimation>().animation;
 				animation.getSprite().setRotation(sf::degrees(transform.angle));
 				animation.getSprite().setPosition({ transform.pos.x, transform.pos.y });
 				animation.getSprite().setScale({ transform.scale.x, transform.scale.y });
@@ -563,10 +564,10 @@ void Scene_Play::sRender()
 	{
 		for (auto e : m_entityManager.getEntities())
 		{
-			if (e->hasComponent<CBoundingBox>())
+			if (e.hasComponent<CBoundingBox>())
 			{
-				auto& box = e->getComponent<CBoundingBox>();
-				auto& transform = e->getComponent<CTransform>();
+				auto& box = e.getComponent<CBoundingBox>();
+				auto& transform = e.getComponent<CTransform>();
 				sf::RectangleShape rect;
 				rect.setSize(sf::Vector2f(box.size.x - 1, box.size.y - 1));
 				rect.setOrigin(sf::Vector2f(box.halfSize.x, box.halfSize.y));

--- a/Scene_Play.cpp
+++ b/Scene_Play.cpp
@@ -169,7 +169,7 @@ void Scene_Play::spawnBullet(Entity entity)
 	auto bullet = m_entityManager.addEntity("Bullet");
 	bullet.addComponent<CTransform>(Vec2(entity.getComponent<CTransform>().pos.x, entity.getComponent<CTransform>().pos.y));
 	bullet.getComponent<CTransform>().scale = entity.getComponent<CTransform>().scale;
-	bullet.getComponent<CTransform>().velocity.x = 0.5f; // bullet.getComponent<CTransform>().scale.x * 15;
+	bullet.getComponent<CTransform>().velocity.x = bullet.getComponent<CTransform>().scale.x * 15;
 	bullet.addComponent<CAnimation>(m_game->assets().getAnimation("BulletAlive"), true);
 	bullet.addComponent<CBoundingBox>(bullet.getComponent<CAnimation>().animation.getSize() * 0.90f);
 	bullet.addComponent<CState>("ALIVE");

--- a/Scene_Play.cpp
+++ b/Scene_Play.cpp
@@ -21,7 +21,8 @@ bool isInside(Vec2 pos, Entity e)
 Scene_Play::Scene_Play(GameEngine* gameEngine, const std::string& levelPath) :
 	Scene(gameEngine),
 	m_levelPath(levelPath),
-	m_gridText(m_game->assets().getFont("Sooky"))
+	m_gridText(m_game->assets().getFont("Sooky")),
+	m_player(m_entityManager.addEntity("Player"))
 {
 	init(m_levelPath);
 }

--- a/Scene_Play.cpp
+++ b/Scene_Play.cpp
@@ -91,19 +91,19 @@ void Scene_Play::loadLevel(const std::string& filename)
 			fin >> name >> tileGX >> tileGY;
 
 			auto tile = m_entityManager.addEntity("Tile");
-			tile->addComponent<CAnimation>(m_game->assets().getAnimation(name), true);
-			tile->addComponent<CTransform>();
-			tile->addComponent<CDraggable>();
+			tile.addComponent<CAnimation>(m_game->assets().getAnimation(name), true);
+			tile.addComponent<CTransform>();
+			tile.addComponent<CDraggable>();
 			if (item == "Decoration")
 			{
-				tile->getComponent<CTransform>().scale = { 5.0, 7.0 };
+				tile.getComponent<CTransform>().scale = { 5.0, 7.0 };
 			}
-			tile->getComponent<CTransform>().pos = gridToMidPixel(tileGX, tileGY, tile);
+			tile.getComponent<CTransform>().pos = gridToMidPixel(tileGX, tileGY, tile);
 			if (item == "Tile")
 			{
 				// Decorations should not have a bounding box
-				tile->addComponent<CBoundingBox>(Vec2(tile->getComponent<CAnimation>().animation.getSize().x, tile->getComponent<CAnimation>().animation.getSize().y));
-				tile->addComponent<CState>("ALIVE");
+				tile.addComponent<CBoundingBox>(Vec2(tile.getComponent<CAnimation>().animation.getSize().x, tile.getComponent<CAnimation>().animation.getSize().y));
+				tile.addComponent<CState>("ALIVE");
 			}
 		}
 		else if (item == "Enemy")
@@ -114,11 +114,11 @@ void Scene_Play::loadLevel(const std::string& filename)
 			fin >> name >> tileGX >> tileGY >> damage;
 
 			auto enemy = m_entityManager.addEntity("Enemy");
-			enemy->addComponent<CAnimation>(m_game->assets().getAnimation(name), true);
-			enemy->addComponent<CTransform>();
-			enemy->getComponent<CTransform>().pos = gridToMidPixel(tileGX, tileGY, enemy);
-			enemy->addComponent<CBoundingBox>(Vec2(enemy->getComponent<CAnimation>().animation.getSize().x * 0.85f, enemy->getComponent<CAnimation>().animation.getSize().y * 0.85f));
-			enemy->addComponent<CState>("ALIVE");
+			enemy.addComponent<CAnimation>(m_game->assets().getAnimation(name), true);
+			enemy.addComponent<CTransform>();
+			enemy.getComponent<CTransform>().pos = gridToMidPixel(tileGX, tileGY, enemy);
+			enemy.addComponent<CBoundingBox>(Vec2(enemy.getComponent<CAnimation>().animation.getSize().x * 0.85f, enemy.getComponent<CAnimation>().animation.getSize().y * 0.85f));
+			enemy.addComponent<CState>("ALIVE");
 		}
 		else if (item == "Player")
 		{
@@ -155,24 +155,24 @@ void Scene_Play::spawnPlayer()
 {
 	// Here is a sample player entity which you can use to construct other entities
 	m_player = m_entityManager.addEntity("Player");
-	m_player->addComponent<CAnimation>(m_game->assets().getAnimation("PlayerJump"), true);
-	m_player->addComponent<CTransform>(Vec2(gridToMidPixel(m_playerConfig.gridX, m_playerConfig.gridY, m_player)));
-	m_player->addComponent<CState>().state = "JUMPING";
-	m_player->addComponent<CBoundingBox>(Vec2(m_playerConfig.collisionX, m_playerConfig.collisionY));
-	m_player->addComponent<CGravity>(m_playerConfig.gravity);
+	m_player.addComponent<CAnimation>(m_game->assets().getAnimation("PlayerJump"), true);
+	m_player.addComponent<CTransform>(Vec2(gridToMidPixel(m_playerConfig.gridX, m_playerConfig.gridY, m_player)));
+	m_player.addComponent<CState>().state = "JUMPING";
+	m_player.addComponent<CBoundingBox>(Vec2(m_playerConfig.collisionX, m_playerConfig.collisionY));
+	m_player.addComponent<CGravity>(m_playerConfig.gravity);
 }
 
 void Scene_Play::spawnBullet(std::shared_ptr<Entity> entity)
 {
 	// TODO: This should spawn a bullet at the given entity, going in the direction the entity is facing
 	auto bullet = m_entityManager.addEntity("Bullet");
-	bullet->addComponent<CTransform>(Vec2(entity->getComponent<CTransform>().pos.x, entity->getComponent<CTransform>().pos.y));
-	bullet->getComponent<CTransform>().scale = entity->getComponent<CTransform>().scale;
-	bullet->getComponent<CTransform>().velocity.x = bullet->getComponent<CTransform>().scale.x * 15;
-	bullet->addComponent<CAnimation>(m_game->assets().getAnimation("BulletAlive"), true);
-	bullet->addComponent<CBoundingBox>(bullet->getComponent<CAnimation>().animation.getSize() * 0.90f);
-	bullet->addComponent<CState>("ALIVE");
-	bullet->addComponent<CLifespan>(600, m_currentFrame);
+	bullet.addComponent<CTransform>(Vec2(entity.getComponent<CTransform>().pos.x, entity.getComponent<CTransform>().pos.y));
+	bullet.getComponent<CTransform>().scale = entity.getComponent<CTransform>().scale;
+	bullet.getComponent<CTransform>().velocity.x = bullet.getComponent<CTransform>().scale.x * 15;
+	bullet.addComponent<CAnimation>(m_game->assets().getAnimation("BulletAlive"), true);
+	bullet.addComponent<CBoundingBox>(bullet.getComponent<CAnimation>().animation.getSize() * 0.90f);
+	bullet.addComponent<CState>("ALIVE");
+	bullet.addComponent<CLifespan>(600, m_currentFrame);
 }
 
 void Scene_Play::update()
@@ -195,9 +195,9 @@ void Scene_Play::sDragAndDrop()
 {
 	for (auto e : m_entityManager.getEntities())
 	{
-		if (e->hasComponent<CDraggable>() && e->getComponent<CDraggable>().dragging)
+		if (e.hasComponent<CDraggable>() && e.getComponent<CDraggable>().dragging)
 		{
-			e->getComponent<CTransform>().pos = windowToWorld(m_mPos);
+			e.getComponent<CTransform>().pos = windowToWorld(m_mPos);
 		}
 	}
 }
@@ -206,11 +206,11 @@ void Scene_Play::sLifespan()
 {
 	for (auto& e : m_entityManager.getEntities())
 	{
-		if (e->hasComponent<CLifespan>())
+		if (e.hasComponent<CLifespan>())
 		{
-			if (m_currentFrame - e->getComponent<CLifespan>().frameCreated > e->getComponent<CLifespan>().lifespan)
+			if (m_currentFrame - e.getComponent<CLifespan>().frameCreated > e.getComponent<CLifespan>().lifespan)
 			{
-				e->destroy();
+				e.destroy();
 			}
 		}
 	}
@@ -240,46 +240,46 @@ void Scene_Play::sStatus()
 
 	for (auto& e : m_entityManager.getEntities())
 	{
-		if (e->hasComponent<CState>())
+		if (e.hasComponent<CState>())
 		{
-			if (e->tag() == "Player")
+			if (e.tag() == "Player")
 			{
-				if (e->getComponent<CState>().state == "IDLE" && e->getComponent<CAnimation>().animation.getName() != "PlayerIdle")
+				if (e.getComponent<CState>().state == "IDLE" && e.getComponent<CAnimation>().animation.getName() != "PlayerIdle")
 				{
-					e->getComponent<CAnimation>().animation = m_game->assets().getAnimation("PlayerIdle");
+					e.getComponent<CAnimation>().animation = m_game->assets().getAnimation("PlayerIdle");
 				}
-				else if (e->getComponent<CState>().state == "JUMPING" && e->getComponent<CAnimation>().animation.getName() != "PlayerJump")
+				else if (e.getComponent<CState>().state == "JUMPING" && e.getComponent<CAnimation>().animation.getName() != "PlayerJump")
 				{
-					e->getComponent<CAnimation>().animation = m_game->assets().getAnimation("PlayerJump");
+					e.getComponent<CAnimation>().animation = m_game->assets().getAnimation("PlayerJump");
 				}
-				else if (e->getComponent<CState>().state == "RUNNING" && e->getComponent<CAnimation>().animation.getName() != "PlayerRun")
+				else if (e.getComponent<CState>().state == "RUNNING" && e.getComponent<CAnimation>().animation.getName() != "PlayerRun")
 				{
-					e->getComponent<CAnimation>().animation = m_game->assets().getAnimation("PlayerRun");
+					e.getComponent<CAnimation>().animation = m_game->assets().getAnimation("PlayerRun");
 				}
-				else if (e->getComponent<CState>().state == "SHOOTING")
+				else if (e.getComponent<CState>().state == "SHOOTING")
 				{
 					// TODO
 				}
-				else if (e->getComponent<CState>().state == "CROUCHING")
+				else if (e.getComponent<CState>().state == "CROUCHING")
 				{
 					// TODO
 				}
 			}
-			else if (e->tag() == "Bullet")
+			else if (e.tag() == "Bullet")
 			{
-				if (e->getComponent<CState>().state == "DEAD" && e->getComponent<CAnimation>().animation.getName() != "BulletDead")
+				if (e.getComponent<CState>().state == "DEAD" && e.getComponent<CAnimation>().animation.getName() != "BulletDead")
 				{
-					e->getComponent<CTransform>().velocity = Vec2(0, 0);
-					e->getComponent<CAnimation>().animation = m_game->assets().getAnimation("BulletDead");
-					e->getComponent<CAnimation>().repeat = false;
+					e.getComponent<CTransform>().velocity = Vec2(0, 0);
+					e.getComponent<CAnimation>().animation = m_game->assets().getAnimation("BulletDead");
+					e.getComponent<CAnimation>().repeat = false;
 				}
 			}
-			else if (e->tag() == "Tile")
+			else if (e.tag() == "Tile")
 			{
-				if (e->getComponent<CState>().state == "DEAD" && e->getComponent<CAnimation>().animation.getName() != "GroundDead")
+				if (e.getComponent<CState>().state == "DEAD" && e.getComponent<CAnimation>().animation.getName() != "GroundDead")
 				{
-					e->getComponent<CAnimation>().animation = m_game->assets().getAnimation("GroundDead");
-					e->getComponent<CAnimation>().repeat = false;
+					e.getComponent<CAnimation>().animation = m_game->assets().getAnimation("GroundDead");
+					e.getComponent<CAnimation>().repeat = false;
 				}
 			}
 		}
@@ -288,95 +288,95 @@ void Scene_Play::sStatus()
 
 void Scene_Play::sMovement()
 {
-	if (m_pIsOnGround && !m_player->getComponent<CInput>().up)
+	if (m_pIsOnGround && !m_player.getComponent<CInput>().up)
 	{
-		m_player->getComponent<CInput>().canJump = true;
+		m_player.getComponent<CInput>().canJump = true;
 	}
 
-	if (m_player->getComponent<CInput>().shoot && m_player->getComponent<CInput>().canShoot)
+	if (m_player.getComponent<CInput>().shoot && m_player.getComponent<CInput>().canShoot)
 	{
 		spawnBullet(m_player);
-		m_player->getComponent<CInput>().canShoot = false;
+		m_player.getComponent<CInput>().canShoot = false;
 	}
 
 	for (auto e : m_entityManager.getEntities())
 	{
 		// Before we do anything, make a copy of the entity's position
-		e->getComponent<CTransform>().prevPos = e->getComponent<CTransform>().pos;
+		e.getComponent<CTransform>().prevPos = e.getComponent<CTransform>().pos;
 
-		if (e->hasComponent<CGravity>())
+		if (e.hasComponent<CGravity>())
 		{
-			if (e->tag() == "Player")
+			if (e.tag() == "Player")
 			{
 				// SET PLAYER X-VELOCITY
-				if (e->getComponent<CInput>().right || e->getComponent<CInput>().left)
+				if (e.getComponent<CInput>().right || e.getComponent<CInput>().left)
 				{
-					e->getComponent<CTransform>().velocity.x = e->getComponent<CInput>().right ? m_playerConfig.speedX : -m_playerConfig.speedX;
-					e->getComponent<CTransform>().scale.x = e->getComponent<CInput>().right ? 1 : -1;
+					e.getComponent<CTransform>().velocity.x = e.getComponent<CInput>().right ? m_playerConfig.speedX : -m_playerConfig.speedX;
+					e.getComponent<CTransform>().scale.x = e.getComponent<CInput>().right ? 1 : -1;
 					if (m_pIsOnGround)
 					{
-						e->getComponent<CState>().state = "RUNNING";
+						e.getComponent<CState>().state = "RUNNING";
 					}
 				}
-				else if (!e->getComponent<CInput>().right && !e->getComponent<CInput>().left)
+				else if (!e.getComponent<CInput>().right && !e.getComponent<CInput>().left)
 				{
-					e->getComponent<CTransform>().velocity.x = 0.0f;
+					e.getComponent<CTransform>().velocity.x = 0.0f;
 					if (m_pIsOnGround)
 					{
-						e->getComponent<CState>().state = "IDLE";
+						e.getComponent<CState>().state = "IDLE";
 					}
 				}
 
 				// SET PLAYER Y-VELOCITY
-				if (e->getComponent<CInput>().up && e->getComponent<CInput>().canJump && m_pIsOnGround)
+				if (e.getComponent<CInput>().up && e.getComponent<CInput>().canJump && m_pIsOnGround)
 				{
-					e->getComponent<CTransform>().velocity.y = m_playerConfig.speedY;
-					e->getComponent<CState>().state = "JUMPING";
-					e->getComponent<CInput>().canJump = false;
+					e.getComponent<CTransform>().velocity.y = m_playerConfig.speedY;
+					e.getComponent<CState>().state = "JUMPING";
+					e.getComponent<CInput>().canJump = false;
 					m_pIsOnGround = false;
 				}
-				else if (!e->getComponent<CInput>().canJump && !m_pIsOnGround && e->getComponent<CInput>().up)
+				else if (!e.getComponent<CInput>().canJump && !m_pIsOnGround && e.getComponent<CInput>().up)
 				{
-					e->getComponent<CTransform>().velocity.y += e->getComponent<CTransform>().velocity.y + e->getComponent<CGravity>().gravity;
+					e.getComponent<CTransform>().velocity.y += e.getComponent<CTransform>().velocity.y + e.getComponent<CGravity>().gravity;
 				}
-				else if (!e->getComponent<CInput>().canJump && !m_pIsOnGround && !e->getComponent<CInput>().up)
+				else if (!e.getComponent<CInput>().canJump && !m_pIsOnGround && !e.getComponent<CInput>().up)
 				{
-					e->getComponent<CTransform>().velocity.y += e->getComponent<CGravity>().gravity;
+					e.getComponent<CTransform>().velocity.y += e.getComponent<CGravity>().gravity;
 				}
 				else
 				{
-					e->getComponent<CTransform>().velocity.y += e->getComponent<CGravity>().gravity;
+					e.getComponent<CTransform>().velocity.y += e.getComponent<CGravity>().gravity;
 				}
 
-				e->getComponent<CGravity>().gravity *= 1.1;
+				e.getComponent<CGravity>().gravity *= 1.1;
 			}
 			else
 			{
-				e->getComponent<CTransform>().velocity.y += e->getComponent<CGravity>().gravity;
+				e.getComponent<CTransform>().velocity.y += e.getComponent<CGravity>().gravity;
 			}
 		}
 
 		// Cap entities speed in all directions using player's max speed (ideally entities should have their own max speed)
-		if (e->getComponent<CTransform>().velocity.x > m_playerConfig.maxSpeed)
+		if (e.getComponent<CTransform>().velocity.x > m_playerConfig.maxSpeed)
 		{
-			e->getComponent<CTransform>().velocity.x = m_playerConfig.maxSpeed;
+			e.getComponent<CTransform>().velocity.x = m_playerConfig.maxSpeed;
 		}
-		if (e->getComponent<CTransform>().velocity.x < -m_playerConfig.maxSpeed)
+		if (e.getComponent<CTransform>().velocity.x < -m_playerConfig.maxSpeed)
 		{
-			e->getComponent<CTransform>().velocity.x = -m_playerConfig.maxSpeed;
+			e.getComponent<CTransform>().velocity.x = -m_playerConfig.maxSpeed;
 		}
-		if (e->getComponent<CTransform>().velocity.y > m_playerConfig.maxSpeed)
+		if (e.getComponent<CTransform>().velocity.y > m_playerConfig.maxSpeed)
 		{
-			e->getComponent<CTransform>().velocity.y = m_playerConfig.maxSpeed;
+			e.getComponent<CTransform>().velocity.y = m_playerConfig.maxSpeed;
 		}
-		if (e->getComponent<CTransform>().velocity.y < -m_playerConfig.maxSpeed)
+		if (e.getComponent<CTransform>().velocity.y < -m_playerConfig.maxSpeed)
 		{
-			e->getComponent<CTransform>().velocity.y = -m_playerConfig.maxSpeed;
+			e.getComponent<CTransform>().velocity.y = -m_playerConfig.maxSpeed;
 		}
 
 
 		// Velocity has been managed, now update entity position using the updated volocity
-		e->getComponent<CTransform>().pos += e->getComponent<CTransform>().velocity;
+		e.getComponent<CTransform>().pos += e.getComponent<CTransform>().velocity;
 	}
 }
 
@@ -384,7 +384,7 @@ void Scene_Play::sCollision()
 {
 	// Player collision with tiles
 	Vec2 overlap(0, 0);
-	auto& pPos = m_player->getComponent<CTransform>();
+	auto& pPos = m_player.getComponent<CTransform>();
 
 	for (auto& e : m_entityManager.getEntities("Tile"))
 	{
@@ -401,7 +401,7 @@ void Scene_Play::sCollision()
 					// Falling into a block
 					pPos.pos.y -= overlap.y;
 					pPos.velocity.y = 0.0f;
-					m_player->getComponent<CGravity>().gravity = m_playerConfig.gravity;
+					m_player.getComponent<CGravity>().gravity = m_playerConfig.gravity;
 					m_pIsOnGround = true;
 				}
 				else
@@ -435,21 +435,21 @@ void Scene_Play::sCollision()
 			overlap = Physics::GetOverlap(e, b);
 			if (overlap.x > 0 && overlap.y > 0)
 			{
-				b->getComponent<CState>().state = "DEAD";
-				e->getComponent<CState>().state = "DEAD";
+				b.getComponent<CState>().state = "DEAD";
+				e.getComponent<CState>().state = "DEAD";
 			}
 		}
 	}
 
 	// Not using bounding box here since we want the player to completely exit the screen before we respawn them
-	if (m_player->getComponent<CTransform>().pos.y > m_game->window().getSize().y + m_player->getComponent<CAnimation>().animation.getSize().y)
+	if (m_player.getComponent<CTransform>().pos.y > m_game->window().getSize().y + m_player.getComponent<CAnimation>().animation.getSize().y)
 	{
-		m_player->getComponent<CTransform>().pos = gridToMidPixel(m_playerConfig.gridX, m_playerConfig.gridY, m_player);
+		m_player.getComponent<CTransform>().pos = gridToMidPixel(m_playerConfig.gridX, m_playerConfig.gridY, m_player);
 	}
 	// Player can not walk off the left side of the screen
-	if (m_player->getComponent<CTransform>().pos.x - m_player->getComponent<CBoundingBox>().halfSize.x < 0)
+	if (m_player.getComponent<CTransform>().pos.x - m_player.getComponent<CBoundingBox>().halfSize.x < 0)
 	{
-		m_player->getComponent<CTransform>().pos.x = m_player->getComponent<CBoundingBox>().halfSize.x;
+		m_player.getComponent<CTransform>().pos.x = m_player.getComponent<CBoundingBox>().halfSize.x;
 	}
 }
 
@@ -475,10 +475,10 @@ void Scene_Play::sDoAction(const Action& action)
 			//std::cout << "Mouse clicked at: " << worldPos.x << ", " << worldPos.y << std::endl;
 			for (auto& e : m_entityManager.getEntities())
 			{
-				if (e->hasComponent<CDraggable>() && isInside(worldPos, e))
+				if (e.hasComponent<CDraggable>() && isInside(worldPos, e))
 				{
-					std::cout << "CLICKED ON ENTITY: " << e->getComponent<CAnimation>().animation.getName() << std::endl;
-					e->getComponent<CDraggable>().dragging = !e->getComponent<CDraggable>().dragging;
+					std::cout << "CLICKED ON ENTITY: " << e.getComponent<CAnimation>().animation.getName() << std::endl;
+					e.getComponent<CDraggable>().dragging = !e.getComponent<CDraggable>().dragging;
 				}
 			}
 		}
@@ -496,8 +496,8 @@ void Scene_Play::sDoAction(const Action& action)
 		if (action.name() == "RIGHT")				{ m_player->getComponent<CInput>().right = false; }
 		if (action.name() == "SHOOT") 
 		{
-			m_player->getComponent<CInput>().canShoot = true;
-			m_player->getComponent<CInput>().shoot = false;
+			m_player.getComponent<CInput>().canShoot = true;
+			m_player.getComponent<CInput>().shoot = false;
 		}
 	}
 }

--- a/Scene_Play.cpp
+++ b/Scene_Play.cpp
@@ -22,7 +22,7 @@ Scene_Play::Scene_Play(GameEngine* gameEngine, const std::string& levelPath) :
 	Scene(gameEngine),
 	m_levelPath(levelPath),
 	m_gridText(m_game->assets().getFont("Sooky")),
-	m_player(m_entityManager.addEntity("Player"))
+	m_player(m_entityManager.addEntity("Default"))
 {
 	init(m_levelPath);
 }
@@ -156,7 +156,7 @@ void Scene_Play::loadLevel(const std::string& filename)
 
 void Scene_Play::spawnPlayer()
 {
-	//m_player = m_entityManager.addEntity("Player");
+	m_player = m_entityManager.addEntity("Player");
 	m_player.addComponent<CAnimation>(m_game->assets().getAnimation("PlayerJump"), true);
 	m_player.addComponent<CTransform>(Vec2(gridToMidPixel(m_playerConfig.gridX, m_playerConfig.gridY, m_player)));
 	m_player.addComponent<CState>().state = "JUMPING";
@@ -166,11 +166,10 @@ void Scene_Play::spawnPlayer()
 
 void Scene_Play::spawnBullet(Entity entity)
 {
-	// TODO: This should spawn a bullet at the given entity, going in the direction the entity is facing
 	auto bullet = m_entityManager.addEntity("Bullet");
 	bullet.addComponent<CTransform>(Vec2(entity.getComponent<CTransform>().pos.x, entity.getComponent<CTransform>().pos.y));
 	bullet.getComponent<CTransform>().scale = entity.getComponent<CTransform>().scale;
-	bullet.getComponent<CTransform>().velocity.x = bullet.getComponent<CTransform>().scale.x * 15;
+	bullet.getComponent<CTransform>().velocity.x = 0.5f; // bullet.getComponent<CTransform>().scale.x * 15;
 	bullet.addComponent<CAnimation>(m_game->assets().getAnimation("BulletAlive"), true);
 	bullet.addComponent<CBoundingBox>(bullet.getComponent<CAnimation>().animation.getSize() * 0.90f);
 	bullet.addComponent<CState>("ALIVE");

--- a/Scene_Play.h
+++ b/Scene_Play.h
@@ -14,14 +14,8 @@ class Scene_Play : public Scene
 		std::string WEAPON;
 	};
 
-	struct EnemyConfig
-	{
-		float gridX = 0, gridY = 0, collisionX = 0, collisionY = 0, speedX = 0, speedY = 0, maxSpeed = 0, gravity = 0, damage = 0;
-	};
-
 protected:
-
-	std::shared_ptr<Entity>				m_player;
+	Entity								m_player = m_entityManager.addEntity("Player");
 	std::string							m_levelPath;
 	std::string							m_lastAction;
 	PlayerConfig						m_playerConfig;
@@ -35,7 +29,7 @@ protected:
 	Vec2								m_mPos;
 	sf::CircleShape						m_mouseShape;
 
-	Vec2 gridToMidPixel(float gridX, float gridY, std::shared_ptr<Entity>);
+	Vec2 gridToMidPixel(float gridX, float gridY, Entity);
 	Vec2 windowToWorld(const Vec2& windowPos) const;
 
 	void init(const std::string& levelPath);
@@ -44,7 +38,7 @@ protected:
 	void update();
 
 	void spawnPlayer();
-	void spawnBullet(std::shared_ptr<Entity> entity);
+	void spawnBullet(Entity entity);
 
 	void sDragAndDrop();
 	void sDoAction(const Action& action);

--- a/Scene_Play.h
+++ b/Scene_Play.h
@@ -15,7 +15,7 @@ class Scene_Play : public Scene
 	};
 
 protected:
-	Entity								m_player = m_entityManager.addEntity("Player");
+	Entity								m_player;
 	std::string							m_levelPath;
 	std::string							m_lastAction;
 	PlayerConfig						m_playerConfig;


### PR DESCRIPTION
Replaced the old-way of handling Entity-Component relationships with a new system.

New system uses memory pooling for components, and uses an integer (size_t) index (wrapped by Entity class) to index different components, which live contiguously in memory allocated at the beginning of Scene_Play.

* The intention of this changes was to take advantage of cache coherency, as when one entity's component is grabbed, surrounding entities' components of the same type are stored in cache memory. This significantly increases the speed at which we access different entities' components as we often loop through all entities to check their components (ie. Animation->Sprite, Transform->Position, etc).

The current maximum number of entities is set to 1,000,000 (one million) and is overkill for what I need it to do, but this was a good exercise in optimizing my game while learning something new.

And the best part...now I can focus on adding features to my game :)