### PR TITLE
SAD-11 - Add Damage Component

### DIFF
--- a/Components.h
+++ b/Components.h
@@ -36,6 +36,14 @@ public:
 	CClimbable() {};
 };
 
+class CDamage : public Component
+{
+public:
+	float damage = 0;
+	CDamage() {};
+	CDamage(float d) : damage(d) {};
+};
+
 class CDraggable : public Component
 {
 public:
@@ -58,6 +66,10 @@ public:
 	float currentHealth = 100;
 
 	CHealth() {};
+	CHealth(float mh) :
+		maxHealth(mh),
+		currentHealth(mh)
+	{ };
 };
 
 class CInput : public Component

--- a/EntityMemoryPool.h
+++ b/EntityMemoryPool.h
@@ -12,6 +12,7 @@ typedef std::tuple<
 	std::vector<CAnimation>,
 	std::vector<CBoundingBox>,
 	std::vector<CClimbable>,
+	std::vector<CDamage>,
 	std::vector<CDraggable>,
 	std::vector<CGravity>,
 	std::vector<CHealth>,

--- a/Scene_Play.h
+++ b/Scene_Play.h
@@ -45,6 +45,7 @@ protected:
 	void sMovement();
 	void sStatus();
 	void sAnimation();
+	void sDisplayHealth();
 	void sCollision();
 	void sLifespan();
 	void sCamera();


### PR DESCRIPTION
SAD-11 - Add Damage Component - Added a damage component for bullets. Added logic within the collision system to detect when a bullet collides with an enemy to subtract the damage from the enemy's health. Hardcoded health to 50 and damage to 10 until I get around to modifying the config to contain those values. Also added a health bar which will appear once an enemy has taken damage and update to reflect the overall health left of a given enemy based on the remaining health of the enemy. 