### PR TITLE
SAD-28 - CDestroyable Component Implementation

### DIFF
--- a/Components.h
+++ b/Components.h
@@ -44,6 +44,12 @@ public:
 	CDamage(float d) : damage(d) {};
 };
 
+class CDestroyable : public Component
+{
+public:
+	CDestroyable() {};
+};
+
 class CDraggable : public Component
 {
 public:

--- a/EntityManager.cpp
+++ b/EntityManager.cpp
@@ -57,3 +57,18 @@ const EntityVec& EntityManager::getEntities(const std::string& tag)
 {
 	return m_entityMap[tag];
 }
+
+const EntityVec& EntityManager::getEntities(const std::vector<std::string>& tags)
+{
+	m_tagged.clear();
+
+	for (const auto& tag : tags)
+	{
+		for (auto& b : m_entityMap[tag])
+		{
+			m_tagged.push_back(b);
+		}
+	}
+
+	return m_tagged;
+}

--- a/EntityManager.h
+++ b/EntityManager.h
@@ -11,6 +11,7 @@ typedef std::vector<Entity> EntityVec;
 
 class EntityManager
 {
+	EntityVec										m_tagged;					// For returning multiple tags
 	EntityVec										m_entities;					// All entities
 	EntityVec										m_entitiesToAdd;			// Entities to add next update
 	std::map<std::string, EntityVec>				m_entityMap;				// Map from entity tag to vectors
@@ -28,5 +29,6 @@ public:
 
 	const EntityVec& getEntities();
 	const EntityVec& getEntities(const std::string& tag);
+	const EntityVec& getEntities(const std::vector<std::string>& tags);
 
 };

--- a/EntityMemoryPool.h
+++ b/EntityMemoryPool.h
@@ -13,6 +13,7 @@ typedef std::tuple<
 	std::vector<CBoundingBox>,
 	std::vector<CClimbable>,
 	std::vector<CDamage>,
+	std::vector<CDestroyable>,
 	std::vector<CDraggable>,
 	std::vector<CGravity>,
 	std::vector<CGridLocation>,

--- a/Scene_LevelEditor.cpp
+++ b/Scene_LevelEditor.cpp
@@ -84,7 +84,7 @@ void Scene_LevelEditor::loadLevel(const std::string& filename)
 
 	while (fin >> item)
 	{
-		if (item == "Tile" || item == "Decoration" || item == "Ladder")
+		if (item == "Tile" || item == "Decoration" || item == "Ladder" || item == "Destroyable")
 		{
 
 			int tileGX = 0, tileGY = 0;
@@ -220,7 +220,7 @@ void Scene_LevelEditor::saveLevel(const std::string& levelPath)
 						int(e.getComponent<CDamage>().damage) << " \n";
 
 				}
-				if (e.tag() == "Tile" || e.tag() == "Decoration" || e.tag() == "Ladder")
+				if (e.tag() == "Tile" || e.tag() == "Decoration" || e.tag() == "Ladder" || e.tag() == "Destroyable")
 				{
 					fout << 
 						e.tag() << " " << 
@@ -258,6 +258,10 @@ void Scene_LevelEditor::loadTileSheet(const std::string& tilesheet)
 			auto ne = m_entityPoolManager.addEntity(entityType);
 			ne.addComponent<CAnimation>(m_game->assets().getAnimation(entityAnim), true);
 			ne.addComponent<CTransform>();
+			if (entityType == "Destroyable")
+			{
+				ne.addComponent<CDestroyable>();
+			}
 		}
 	}
 	else
@@ -496,6 +500,16 @@ void Scene_LevelEditor::sRender()
 		{
 			auto& transform = e.getComponent<CTransform>();
 			auto& animation = e.getComponent<CAnimation>().animation;
+
+			if (e.getComponent<CDestroyable>().has)
+			{
+				sf::RectangleShape rect({ float(animation.getSprite().getTexture().getSize().x), float(animation.getSprite().getTexture().getSize().y)});
+				rect.setOutlineColor(sf::Color::Green);
+				rect.setOutlineThickness(4);
+				rect.setPosition({ transform.pos.x - (animation.getSprite().getTexture().getSize().x / 2), transform.pos.y - (animation.getSprite().getTexture().getSize().y / 2)});
+				m_game->window().draw(rect);
+			}
+
 			animation.getSprite().setRotation(sf::degrees(transform.angle));
 			animation.getSprite().setPosition({ transform.pos.x, transform.pos.y });
 			animation.getSprite().setScale({ transform.scale.x, transform.scale.y });
@@ -503,7 +517,7 @@ void Scene_LevelEditor::sRender()
 		}
 	}
 
-	// Draw the grid so that students can easily debug
+	// Draw the grid for easy viewing of tile placement and world size
 	if (m_drawGrid)
 	{
 		float leftX = m_game->window().getView().getCenter().x - width() / 2;

--- a/assets/assets.txt
+++ b/assets/assets.txt
@@ -11,7 +11,7 @@ Texture TexEnemyRunnerIdle images/EnemyRunnerIdle.png
 Texture TexGroundPurple images/GroundPurple.png
 Texture TexUnderGround images/UnderGround.png
 Texture TexNonEnemyTreeNew images/NonEnemyTreeNew.png
-Texture TexHeartFull images/HeatFull2.png
+Texture TexHeartFull images/HeartFull2.png
 Texture TexHeartEmpty images/HeartEmpty2.png
 Texture TexLampBasic images/DecorationLampBasic.png
 Animation BulletAlive TexBulletAlive 16 2
@@ -21,6 +21,8 @@ Animation PlayerJump TexPlayerJump 8 4
 Animation PlayerRun TexPlayerRun 5 4
 Animation NonEnemyTree TexNonEnemyTree 4 8
 Animation Ground TexGround 1 0
+Animation DestroyableGround TexGround 1 0
+Animation DestroyableUnderGround TexUnderGround 1 0
 Animation GroundPurple TexGroundPurple 1 0
 Animation GroundDead TexGroundDead 8 2
 Animation LadderBone TexLadderBone 1 0

--- a/level_tilesheets/level1.txt
+++ b/level_tilesheets/level1.txt
@@ -1,7 +1,9 @@
 Player PlayerIdle
-Decoration NonEnemyTreeNew
-Decoration LampBasic
 Tile Ground
 Tile UnderGround
+Destroyable DestroyableGround
+Destroyable DestroyableUnderGround
 Ladder LadderBone
 Enemy EnemyRunner
+Decoration NonEnemyTreeNew
+Decoration LampBasic

--- a/levels/level1.txt
+++ b/levels/level1.txt
@@ -173,7 +173,6 @@ Tile UnderGround 44 1
 Tile UnderGround 44 0 
 Tile UnderGround 43 0 
 Decoration NonEnemyTreeNew 9 7 
-Player 1 5 48 48 8 -10 15 2 GUN 
 Tile Ground 40 6 
 Tile Ground 41 5 
 Tile Ground 42 4 
@@ -188,3 +187,11 @@ Tile UnderGround 46 0
 Tile UnderGround 47 0 
 Tile UnderGround 48 0 
 Tile UnderGround 49 0 
+Player 1 5 48 48 8 -10 15 2 GUN 
+Destroyable DestroyableGround 18 8 
+Destroyable DestroyableGround 18 7 
+Destroyable DestroyableUnderGround 18 9 
+Destroyable DestroyableUnderGround 18 10 
+Destroyable DestroyableGround 17 9 
+Destroyable DestroyableGround 19 9 
+Destroyable DestroyableUnderGround 18 6 


### PR DESCRIPTION
Added additional assets, updated the tilesheet. Added a new component CDestroyable which can be added to any tile which we want the player to be able to destroy. This can be used to reveal hidden parts of the map for example, allowing for exploration.

Updated the LevelEditor and the PlayScene. PlayScene now checks to see if a tile is destroyable or not...if not, only the bullet is destroyed upon collision. Level Editor now has a green outline displayed around any tile which has the CDestroyable component. I'm realizing that in the future the game would need a massive overhaul of the LevelEditing system (also, why am I using .txt and not .json???), but for now it does what I need it to do.

Also added an overload function for getEntities in the entity manager which allows for multiple tags and returns a single vector of entities. This will allow me to refactor code which currently uses multiple for-loops for different tags, checking the same thing repeatedly. 