### PR TITLE
SAD-39 - Upgrade Player Camera

### DIFF
--- a/Scene_Play.cpp
+++ b/Scene_Play.cpp
@@ -309,6 +309,7 @@ void Scene_Play::sCamera()
 	// Set the viewport of the window to be centered on the player if it's far enough right
 	auto& pPos = m_player.getComponent<CTransform>().pos;
 	float windowCenterX = std::max(m_game->window().getSize().x / 2.0f, pPos.x);
+	float windowMaxY = m_game->window().getSize().y / 2.0f;
 	sf::View view = m_game->window().getView();
 	float windowCenterY = view.getCenter().y;
 
@@ -319,6 +320,11 @@ void Scene_Play::sCamera()
 	else if (pPos.y > view.getCenter().y)
 	{
 		windowCenterY += camYVelocity;
+	}
+
+	if (pPos.y > windowMaxY && windowCenterY > windowMaxY)
+	{
+		windowCenterY = windowMaxY;
 	}
 
 	view.setCenter({ windowCenterX, windowCenterY });


### PR DESCRIPTION
Added a check for camera height since the camera was centering on the player the entire time. Now the camera will only center on the player in the y-direction when the player is high enough, the camera will follow the player. This gives the world a much better feel and doesn't show below the level. This will need to be improved upon in the future to track the player when he goes lower in the event we want to provide the player with a "dungeon" or something like stairs which descend.